### PR TITLE
Added support for a new duration when resetting a timer

### DIFF
--- a/lib/timer.js
+++ b/lib/timer.js
@@ -43,7 +43,7 @@ class Timer extends Component {
       this.stop();
     }
     if(newProps.reset) {
-      this.reset();
+      this.reset(newProps.totalDuration);
     }
   }
 
@@ -66,8 +66,8 @@ class Timer extends Component {
     clearInterval(this.interval);
   }
 
-  reset() {
-    this.setState({remainingTime: this.props.totalDuration});
+  reset(newDuration) {
+    this.setState({remainingTime: this.props.totalDuration != newDuration ? newDuration : this.props.totalDuration});
   }
 
   formatTime() {


### PR DESCRIPTION
The timer was always resetting to it's current duration, even if the duration was changed in the same call to setState.