### PR TITLE
Add tickInterval option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ import { Stopwatch, Timer } from 'react-native-stopwatch-timer'
 |options|object|describes style of rendered timer/stopwatch|see example|
 |getTime|function|get the formatted value on each tick|(time) => console.log(time)|
 |getMsecs|function|get the number of msecs on each tick|(time) => console.log(time)|
+|tickInterval|number|set the interval for the getTime and getMsecs functions to be executed|1ms
 
 
 #### Stopwatch Options

--- a/lib/stopwatch.js
+++ b/lib/stopwatch.js
@@ -14,6 +14,7 @@ class StopWatch extends Component {
     getTime: PropTypes.func,
     startTime: PropTypes.number,
     getMsecs: PropTypes.func,
+    tickInterval: PropTypes.number
   }
 
   constructor(props) {
@@ -68,6 +69,9 @@ class StopWatch extends Component {
   }
 
   start() {
+    // default to 1 millisecond
+    const tickInterval = this.props.tickInterval || 1
+
     if (this.props.laps && this.state.elapsed) {
       let lap = new Date() - this.state.stopTime;
       this.setState({
@@ -81,7 +85,7 @@ class StopWatch extends Component {
       
     this.interval = this.interval ? this.interval : setInterval(() => {
         this.setState({elapsed: new Date() - this.state.startTime });
-    }, 1);
+    }, tickInterval);
   }
 
   stop() {

--- a/lib/timer.js
+++ b/lib/timer.js
@@ -13,6 +13,7 @@ class Timer extends Component {
     totalDuration: PropTypes.number,
     getTime: PropTypes.func,
     getMsecs: PropTypes.func,
+    tickInterval: PropTypes.number
   }
 
   constructor(props) {
@@ -62,6 +63,8 @@ class Timer extends Component {
   start() {
     const handleFinish = this.props.handleFinish ? this.props.handleFinish : () => alert("Timer Finished");
     const endTime = new Date().getTime() + this.state.remainingTime;
+    // default to 1 millisecond
+    const tickInterval = this.props.tickInterval || 1
     this.interval = setInterval(() => {
       const remaining = endTime - new Date();
       if(remaining <= 1000) {
@@ -71,7 +74,7 @@ class Timer extends Component {
         return;
       }
       this.setState({remainingTime: remaining});
-    }, 1);
+    }, tickInterval);
   }
 
   stop() {


### PR DESCRIPTION
Currently the getTime and getMsecs functions execute every millisecond. This can be a little overkill if you are only wanting to use a timer or stopwatch that does something every second (for example). I have added an optional prop called tickInterval that lets you set the interval manually if you want to reduce updates and function calls (it still defaults to 1ms).

If you set tickInterval to 1000, it will only update every second and therefore only call getTime and getMsecs every second.